### PR TITLE
Add option to post as Abakus in GUI

### DIFF
--- a/config.py
+++ b/config.py
@@ -63,6 +63,10 @@ config = {
                                          'label': 'Bedriftskontakt',
                                          'value': 'bedriftskontakt'
                                      },
+                                     {
+                                         'label': 'Abakus',
+                                         'value': 'default'
+                                     },
                                  ]
                              }]
             }


### PR DESCRIPTION
Enable users to post as Abakus when using the slack GUI.