### PR TITLE
Add action to post anonymous messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,22 +3,24 @@
 > Post messages across Slack workspaces, a docker image built to be deployed as a function in OpenFaaS
 
 The container needs the following environment variables to work:
- * `SIGNING_SECRET` - the Slack app signing secret
- * `TARGET_WEBHOOK` - webhook for the workspace you want to post to
- * `OAUTH_TOKEN` - the Slack app OAuth token
 
-Start and run the image locally: 
+- `SIGNING_SECRET` - the Slack app signing secret
+- `OAUTH_TOKEN` - the Slack app OAuth token
+
+Start and run the image locally:
+
 ```
-docker build -t abakus-fwd . && docker run --rm -p 4000:8080 --env="SIGNING_SECRET=BLABLABLA" --env="TARGET_WEBHOOK=BLABLABLA" --env="OAUTH_TOKEN=BLABLABLA" abakus-fwd
+docker build -t abakus-fwd . && docker run --rm -p 4000:8080 --env="SIGNING_SECRET=BLABLABLA" --env="OAUTH_TOKEN=BLABLABLA" abakus-fwd
 ```
+
 Can easily be tested using serveo.net with `ssh -R SOME-SUBDOMAIN:80:localhost:4000 serveo.net`, and using the URL returned as the request URL for interactive components in your Slack app.
-
 
 Can be deployed using `faas-cli deploy` to also set env variables.
 
-
 To use this with a new Slack app you need to:
+
 1. Enable Interactivity in your app
 2. Set the Request URL to where this app is running
 3. Create a new shortcut (on messages), pick a name and description, and set the callback ID to `x_publish`
-4. Check that your app has the appropriate permission scopes ("Add slash commands and add actions to messages (and view related content)")
+4. Create a new global shortcut with callback ID `anon_abaquery`
+5. Check that your app has the appropriate permission scopes ("Add slash commands and add actions to messages (and view related content)")


### PR DESCRIPTION
This adds a second action that is used to post anonymous messages in
slack. Targeted mainly for abaquery. Also refactors some code to be able
to implement this. Removes the target_webhook and uses chat.postMessage
api instead.
